### PR TITLE
Fix link to projects "homepage"/github

### DIFF
--- a/activeaction.gemspec
+++ b/activeaction.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "A tidy DSL to express batch actions"
   spec.description   = "A tidy DSL to express batch actions"
-  spec.homepage      = "https://github.com/joshmn/activeaction"
+  spec.homepage      = "https://github.com/joshmn/active_action"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
The links shows up e.g. at https://rubygems.org/gems/active_action (and points into the void).

And oh damn, I was 24 days late. Wanted to make a gem called ActiveAction, but you were first ... :)